### PR TITLE
Problem with commands that have more than once argument and saving the command in history before run

### DIFF
--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -32,15 +32,6 @@ class Schedule extends BaseSchedule
             $event->name(md5($command . json_encode($schedule->mapArguments() ?? [])))
                 ->cron($schedule->expression);
 
-            $event->after(function () use ($schedule, $event, $command) {
-                $schedule->histories()->create([
-                    'command' => $command,
-                    'params' => $schedule->params,
-                    'options' => $schedule->options,
-                    'output' => file_get_contents($event->output)
-                ]);
-            });
-
             if ($schedule->even_in_maintenance_mode) {
                 $event->evenInMaintenanceMode();
             }
@@ -73,6 +64,14 @@ class Schedule extends BaseSchedule
                 $event->onOneServer();
             }
 
+            $event->before(function () use ($schedule, $event, $command) {
+                $schedule->histories()->create([
+                    'command' => $command,
+                    'params' => $schedule->params,
+                    'options' => $schedule->options,
+                    'output' => file_get_contents($event->output)
+                ]);
+            });
             unset($event);
         }
 

--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -25,11 +25,11 @@ class Schedule extends BaseSchedule
                 $command = $schedule->command_custom;
                 $event = $this->exec($command);
             } else {
-                $command = $schedule->command . $schedule->mapOptions();
+                $command = $schedule->command.$schedule->mapOptions();
                 $event = $this->command($command, $schedule->mapArguments() ?? []);
             }
-            
-            $event->name(md5($command . json_encode($schedule->mapArguments() ?? [])))
+
+            $event->name(md5($command.json_encode($schedule->mapArguments() ?? [])))
                 ->cron($schedule->expression);
 
             if ($schedule->even_in_maintenance_mode) {
@@ -64,14 +64,18 @@ class Schedule extends BaseSchedule
                 $event->onOneServer();
             }
 
-            $event->before(function () use ($schedule, $event, $command) {
-                $schedule->histories()->create([
-                    'command' => $command,
-                    'params' => $schedule->params,
-                    'options' => $schedule->options,
-                    'output' => file_get_contents($event->output)
-                ]);
-            });
+            $event->before(
+                function () use ($schedule, $event, $command) {
+                    $schedule->histories()->create(
+                        [
+                            'command' => $command,
+                            'params' => $schedule->params,
+                            'options' => $schedule->options,
+                            'output' => file_get_contents($event->output)
+                        ]
+                    );
+                }
+            );
             unset($event);
         }
 

--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -32,6 +32,15 @@ class Schedule extends BaseSchedule
             $event->name(md5($command . json_encode($schedule->mapArguments() ?? [])))
                 ->cron($schedule->expression);
 
+            $event->after(function () use ($schedule, $event, $command) {
+                $schedule->histories()->create([
+                    'command' => $command,
+                    'params' => $schedule->params,
+                    'options' => $schedule->options,
+                    'output' => file_get_contents($event->output)
+                ]);
+            });
+
             if ($schedule->even_in_maintenance_mode) {
                 $event->evenInMaintenanceMode();
             }
@@ -64,14 +73,6 @@ class Schedule extends BaseSchedule
                 $event->onOneServer();
             }
 
-            $event->after(function () use ($schedule, $event, $command) {
-                $schedule->histories()->create([
-                    'command' => $command,
-                    'params' => $schedule->params,
-                    'options' => $schedule->options,
-                    'output' => file_get_contents($event->output)
-                ]);
-            });
             unset($event);
         }
 

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -71,7 +71,7 @@ class Schedule extends Model
 
     public function mapArguments()
     {
-        return [
+        $mapedArguments = [
             array_map(function ($item) {
                 if ($item['type'] === 'function') {
                     return eval("return ${item['value']}");
@@ -80,6 +80,7 @@ class Schedule extends Model
                 return $item['value'];
             }, $this->params ?? [])
         ];
+        return array_filter($mapedArguments[0]);
     }
 
     public function mapOptions()


### PR DESCRIPTION
This PR resolve two problems, the first is in issue #12, and the second is an observation I do.

When some problem occurs before the command runs, for example send the email, the command still run but the history is not saved, I change the `$event->after()` to `event->before()`, and it saves. It makes more sense to me, history should save everything, but maybe I'm wrong.