### PR TITLE
fix: array of null arguments broke the schedule command 

### DIFF
--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -26,7 +26,7 @@ class Schedule extends BaseSchedule
                 $event = $this->exec($command);
             } else {
                 $command = $schedule->command . $schedule->mapOptions();
-                $commandName = $schedule->command . $schedule->mapOptions() . " " . $this->argumentsToString($schedule->mapArguments()[0] ?? []);
+                $commandName = $schedule->command . $schedule->mapOptions() . " " . $this->argumentsToString($schedule->mapArguments() ?? []);
                 $event = $this->command($command, $schedule->mapArguments() ?? []);
             }
 

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -72,7 +72,7 @@ class Schedule extends Model
 
     public function mapArguments()
     {
-        return [
+        $mapedArguments = [
             array_map(function ($item) {
                 $type = $item['type'] ?? 'string';
                 if (isset($item["type"]) && $item['type'] === 'function') {
@@ -82,6 +82,7 @@ class Schedule extends Model
                 return $item['value'];
             }, $this->params ?? [])
         ];
+        return array_filter($mapedArguments[0]);
     }
 
     public function mapOptions()


### PR DESCRIPTION
Running a command that has null arguments ends up breaking the process because the command understands null as a string. To solve this before indicating the arguments to the command, I removed the null arguments. 

Before fix:

`Dump of: $schedule->mapArguments(), $this->argumentsToString($schedule->mapArguments()[0] ?? [])`
![image](https://user-images.githubusercontent.com/48099126/123998624-0b2a8080-d9a8-11eb-86a8-4403c86f3aa6.png)

After fix:
`Dump of: $schedule->mapArguments(), $this->argumentsToString($schedule->mapArguments() ?? [])`
![image](https://user-images.githubusercontent.com/48099126/123998800-36ad6b00-d9a8-11eb-8c88-62a07754ae48.png)

