### PR TITLE
fix: passing mapedArguments as array values

### DIFF
--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -26,8 +26,14 @@ class Schedule extends BaseSchedule
                 $event = $this->exec($command);
             } else {
                 $command = $schedule->command . $schedule->mapOptions();
-                $commandName = $schedule->command . $schedule->mapOptions() . " " . $this->argumentsToString($schedule->mapArguments() ?? []);
-                $event = $this->command($command, array_values($schedule->mapArguments()) ?? []);
+                $commandName =
+                    $schedule->command .
+                    $schedule->mapOptions() . " " .
+                    $this->argumentsToString($schedule->mapArguments() ?? []);
+                $event = $this->command(
+                    $command,
+                    array_values($schedule->mapArguments()) ?? []
+                );
             }
 
             $event->name($commandName)

--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -27,7 +27,7 @@ class Schedule extends BaseSchedule
             } else {
                 $command = $schedule->command . $schedule->mapOptions();
                 $commandName = $schedule->command . $schedule->mapOptions() . " " . $this->argumentsToString($schedule->mapArguments() ?? []);
-                $event = $this->command($command, $schedule->mapArguments() ?? []);
+                $event = $this->command($command, array_values($schedule->mapArguments()) ?? []);
             }
 
             $event->name($commandName)

--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -26,8 +26,8 @@ class Schedule extends BaseSchedule
                 $event = $this->exec($command);
             } else {
                 $command = $schedule->command . $schedule->mapOptions();
-                $commandName =
-                    $schedule->command .
+                $commandName
+                    = $schedule->command .
                     $schedule->mapOptions() . " " .
                     $this->argumentsToString($schedule->mapArguments() ?? []);
                 $event = $this->command(


### PR DESCRIPTION
I noticed a problem when passing the argument array to command creation.

Passing an array in the format key => value, to the method that creates the command, these arguments are formatted like this: "key=value". As you can see in the prints:

schedule->mapArguments():
![image](https://user-images.githubusercontent.com/48099126/125093481-b625f300-e0a8-11eb-9b0e-5a04f325e42b.png)

Argument debug:
![image](https://user-images.githubusercontent.com/48099126/125093529-c342e200-e0a8-11eb-825e-c7e245eaa753.png)

Result:
![image](https://user-images.githubusercontent.com/48099126/125093576-d0f86780-e0a8-11eb-98e6-d84387779432.png)



To solve this it is necessary to transform the key => value array into a normal array using `array_values()`.

array_values(schedule->mapArguments()):
![image](https://user-images.githubusercontent.com/48099126/125093764-04d38d00-e0a9-11eb-9a52-d38af3c49056.png)

Argument debug:
![image](https://user-images.githubusercontent.com/48099126/125093529-c342e200-e0a8-11eb-825e-c7e245eaa753.png)

Result:
![image](https://user-images.githubusercontent.com/48099126/125093904-2df41d80-e0a9-11eb-8b00-6c1a3600a8dc.png)