### PR TITLE
Fix empty output in history.

### DIFF
--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -39,6 +39,9 @@ class Schedule extends BaseSchedule
             $event->name($commandName)
                 ->cron($schedule->expression);
 
+            //ensure output is being captured to write history
+            $event->storeOutput();
+
             if ($schedule->even_in_maintenance_mode) {
                 $event->evenInMaintenanceMode();
             }


### PR DESCRIPTION
Test case:
![2021-08-27_12-54-29](https://user-images.githubusercontent.com/1624839/131109702-d02b9669-bded-4959-9fde-6b2e2376425d.png)

Result:
![2021-08-27_12-53-15](https://user-images.githubusercontent.com/1624839/131109723-78b84aa8-54b4-459f-a2d0-9ae4cd093cd4.png)

Now output is saved to DB. Previously it was stored only if email output was set.