### PR TITLE
Arguments improvement

### DIFF
--- a/resources/views/form.blade.php
+++ b/resources/views/form.blade.php
@@ -38,6 +38,7 @@
                     <div class="col-4">
                         <label>{{ trans('schedule::schedule.fields.data-type') }}</label>
                         <select :name="'params['+argument.name+'][type]'" :value="getArgumentsType(argument.name)" class="form-control">
+                            <option value="disabled" selected="selected">Disabled</option>
                             <option value="string">String</option>
                             <option value="function">Function</option>
                         </select>
@@ -63,6 +64,7 @@
                     <div class="col-4">
                         <label>{{ trans('schedule::schedule.fields.data-type') }}</label>
                         <select :name="'options['+option.name+'][type]'" :value="getOptionsType(option.name)" class="form-control">
+                            <option value="disabled" selected="selected">Disabled</option>
                             <option value="string">String</option>
                             <option value="function">Function</option>
                         </select>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -29,7 +29,9 @@
                             <td>
                                 @if(isset($schedule->options))
                                     @foreach($schedule->options as $param => $value)
-                                        {{ $param }}: {{ $value['value'] }}<br>
+                                        @if (!empty($value['type']) && $value['type'] !== 'disabled')
+                                            --{{ $param }}@if (strlen($value['value']))={{ $value['value'] }}@endif<br>
+                                        @endif
                                     @endforeach
                                 @endif
                             </td>

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -90,15 +90,32 @@ class Schedule extends Model
         $str = '';
         if (isset($this->options) && count($this->options) > 0) {
             foreach ($this->options as $name => $option) {
-                $type = $option['type'] ?? 'string';
-                if ($type === 'function') {
-                    $option['value'] = eval("return ${$option['value']}");
-                } else {
-                    settype($option['value'], $type);
+
+                $type = $option['type'] ?? 'disabled';
+                switch ($type) {
+                    case "function":
+                        $option['value'] = eval("return ${$option['value']}");
+                        break;
+
+                    case "string":
+                        settype($option['value'], $type);
+                        break;
+
+                    case "disabled":
+                    default:
+                        break;
                 }
-                $str .= ' --' . $name . '=' . $option['value'];
+
+                if ($type !== 'disabled') {
+                    if (strlen($option['value'])) {
+                        $str .= ' --'.$name.'='.$option['value'];
+                    } else {
+                        $str .= ' --'.$name;
+                    }
+                }
             }
         }
+
         return $str;
     }
 }


### PR DESCRIPTION
hi, package doesn't support arguments with no values for example:

`backup:run [--filename [FILENAME]] [--only-db] [--db-name [DB-NAME]] [--only-files] [--only-to-disk [ONLY-TO-DISK]] [--disable-notifications] [--timeout [TIMEOUT]]`

I want to execute command: `backup:run --only-db ` without any other arguments. Now I get error  **The "--disable-notifications" option does not accept a value.**  

I added new data type: "Disabled", it means that argument will not be added to a command.
If you need argument - select "string" or "function". String type will create command string like "command arg=value" or "command arg" in case when inputed value is empty.  
In index.blade show only arguments which are in use in a command.

                
![2021-08-31_08-55-40](https://user-images.githubusercontent.com/1624839/131457374-0bb7d1af-d6e4-432f-ac2d-c134f28568c4.png)
![2021-08-31_08-55-52](https://user-images.githubusercontent.com/1624839/131457377-91ffc614-fa6e-4b93-955d-daa34c4dfdb4.png)
![2021-08-31_08-55-17](https://user-images.githubusercontent.com/1624839/131457367-aa7cdcb2-f6da-43fc-bfeb-74462e09bd57.png)


PR changes:
![2021-08-31_09-51-16](https://user-images.githubusercontent.com/1624839/131457886-8bba1870-0ed1-4e3d-92ab-5beef3bd33c8.png)
![2021-08-31_09-51-45](https://user-images.githubusercontent.com/1624839/131457889-debbb9c2-4b63-42e1-b9bd-367a8978ba0d.png)

