### PR TITLE
Introduce the optional ability to specify jobs in groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,18 @@ protected function gate()
 }
 ```
 
-#### Exemples:
+#### Groups:
+
+If you have a lot of jobs, you can make managing them easier by enabling the groups feature in `config/database-schedule.php`:
+
+```php
+    /**
+     * If you have a lot of jobs, you can group them for easier managing of jobs.
+     */
+    'enable_groups' => true,
+```
+
+#### Examples:
 
 If you want to limit access to a route to users who have a certain role, you can do so.
 ```php

--- a/config/database-schedule.php
+++ b/config/database-schedule.php
@@ -12,6 +12,7 @@ return [
         'schedule_histories' => 'schedule_histories'
     ],
     'model' => Schedule::class,
+    'enable_groups' => env('SCHEDULE_ENABLE_GROUPS', false),
     'timezone' => env('SCHEDULE_TIMEZONE', config('app.timezone')),
     'middleware' => 'web',
     'guard' => 'web',

--- a/config/database-schedule.php
+++ b/config/database-schedule.php
@@ -12,14 +12,20 @@ return [
         'schedule_histories' => 'schedule_histories'
     ],
     'model' => Schedule::class,
-    'enable_groups' => env('SCHEDULE_ENABLE_GROUPS', false),
+
     'timezone' => env('SCHEDULE_TIMEZONE', config('app.timezone')),
     'middleware' => 'web',
     'guard' => 'web',
+
     /**
      * If restricted_access is true, the user must be authenticated and meet the definition of `viewDatabaseSchedule` gate
      */
     'restricted_access' => env('SCHEDULE_RESTRICTED_ACCESS', true),
+
+    /**
+     * If you have a lot of jobs, you can group them for easier managing of jobs.
+     */
+    'enable_groups' => env('SCHEDULE_ENABLE_GROUPS', false),
 
     /**
      * Cache settings

--- a/migrations/2021_11_21_170324_add_environments_to_schedules_table.php
+++ b/migrations/2021_11_21_170324_add_environments_to_schedules_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddEnvironmentsToSchedulesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(Config::get('database-schedule.table.schedules', 'schedules'), function (Blueprint $table) {
+            $table->string('environments')->after('expression')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(Config::get('database-schedule.table.schedules', 'schedules'), function (Blueprint $table) {
+            $table->dropColumn('environments');
+        });
+    }
+}

--- a/migrations/2021_11_21_185144_add_groups_to_schedules_table.php
+++ b/migrations/2021_11_21_185144_add_groups_to_schedules_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddGroupsToSchedulesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(Config::get('database-schedule.table.schedules', 'schedules'), function (Blueprint $table) {
+            $table->string('groups')->after('run_in_background')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(Config::get('database-schedule.table.schedules', 'schedules'), function (Blueprint $table) {
+            $table->dropColumn('groups');
+        });
+    }
+}

--- a/resources/lang/en/schedule.php
+++ b/resources/lang/en/schedule.php
@@ -4,7 +4,8 @@ return [
         'list' => 'Schedule List',
         'create' => 'Create new schedule',
         'edit' => 'Edit schedule',
-        'show' => 'Show run history'
+        'show' => 'Show run history',
+        'back_to_application' => 'Back to application'
     ],
     'fields' => [
         'command' => 'Command',
@@ -31,7 +32,8 @@ return [
         'created_at' => 'Created At',
         'updated_at' => 'Updated At',
         'never' => 'Never',
-        'groups' => 'Groups'
+        'groups' => 'Groups',
+        'environments' => 'Environments'
     ],
     'messages' => [
         'no-records-found' => 'No records found.',

--- a/resources/lang/en/schedule.php
+++ b/resources/lang/en/schedule.php
@@ -50,7 +50,8 @@ return [
     ],
     'status' => [
         'active' => 'Active',
-        'inactive' => 'Inactive'
+        'inactive' => 'Inactive',
+        'trashed' => 'Trashed',
     ],
     'buttons' => [
         'create' => 'Create New',
@@ -61,7 +62,8 @@ return [
         'activate' => 'Activate',
         'delete' => 'Delete',
         'history' => 'History',
-        'cancel' => 'Cancel'
+        'cancel' => 'Cancel',
+        'restore' => 'Restore'
     ],
     'validation' => [
         'cron' => 'The field must be filled in the cron expression format.',

--- a/resources/lang/en/schedule.php
+++ b/resources/lang/en/schedule.php
@@ -30,7 +30,8 @@ return [
         'run_in_background' => 'Run in background',
         'created_at' => 'Created At',
         'updated_at' => 'Updated At',
-        'never' => 'Never'
+        'never' => 'Never',
+        'groups' => 'Groups'
     ],
     'messages' => [
         'no-records-found' => 'No records found.',
@@ -42,6 +43,7 @@ return [
         'custom-command-here' => 'Custom Command here (e.g. `cat /proc/cpuinfo` or `artisan db:migrate`)',
         'help-cron-expression' => 'If necessary click here and use a tool to facilitate the creation of the cron expression',
         'help-log-filename' => 'If log file is set, the log messages from this cron are written to storage/logs/<log filename>.log',
+        'help-type' => 'Multiple :type can be specified separated by commas',
         'attention-type-function' => "ATTENTION: parameters of the type 'function' are executed before the execution of the scheduling and its return is passed as parameter. Use with care, it can break your job",
         'delete_cronjob' => 'Delete cronjob',
         'delete_cronjob_confirm' => 'Do you really want to delete the cronjob ":cronjob"?'
@@ -60,5 +62,9 @@ return [
         'delete' => 'Delete',
         'history' => 'History',
         'cancel' => 'Cancel'
+    ],
+    'validation' => [
+        'cron' => 'The field must be filled in the cron expression format.',
+        'regex' => trans('validation.alpha_dash') . ' ' . 'Comma is also allowed.'
     ]
 ];

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -1,7 +1,7 @@
 @extends('schedule::layout.master')
 
 @section('content')
-    <div class="container-fluid">
+    <div class="container">
         @include('schedule::messages')
         <form action="{{ action('\RobersonFaria\DatabaseSchedule\Http\Controllers\ScheduleController@store') }}" method="POST">
             @csrf

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -1,0 +1,6 @@
+<select @change="{{ $js }}" class="form-control" name="{{ $name }}" form="schedule-filter-form">
+    <option {{ empty($selected) ? 'selected' : '' }} value=""></option>
+    @foreach ($options as $value => $caption)
+        <option {{ (string) $value === (string) $selected ? 'selected' : '' }} value="{{ $value }}">{{ $caption }}</option>
+    @endforeach
+</select>

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -1,7 +1,7 @@
 @extends('schedule::layout.master')
 
 @section('content')
-    <div class="container-fluid">
+    <div class="container">
         @include('schedule::messages')
         <form action="{{ action('\RobersonFaria\DatabaseSchedule\Http\Controllers\ScheduleController@update', $schedule) }}" method="POST">
             @method('PUT')

--- a/resources/views/form.blade.php
+++ b/resources/views/form.blade.php
@@ -169,6 +169,19 @@
     @endif
 
     <div class="form-group">
+        <label>{{ trans('schedule::schedule.fields.environments') }}</label>
+        <input type="text" class="form-control @error('environments') is-invalid @enderror" name="environments"
+               id="environments"
+               value="{{ old('environments', $schedule->environments ?? '') }}">
+        @error('environments')
+            <div class="invalid-feedback">{{ $message }}</div>
+        @enderror
+        <small id="environmentsHelpBlock" class="form-text text-muted">
+            {{ trans('schedule::schedule.messages.help-type', ['type' => strtolower(trans('schedule::schedule.fields.environments'))]) }}
+        </small>
+    </div>
+
+    <div class="form-group">
         <label>{{ trans('schedule::schedule.fields.log_filename') }}</label>
         <input type="text" class="form-control @error('log_filename') is-invalid @enderror" name="log_filename"
                id="log_filename"

--- a/resources/views/form.blade.php
+++ b/resources/views/form.blade.php
@@ -153,10 +153,25 @@
         @endif
     </div>
 
+    @if(config('database-schedule.enable_groups', false))
+        <div class="form-group">
+            <label>{{ trans('schedule::schedule.fields.groups') }}</label>
+            <input type="text" class="form-control @error('groups') is-invalid @enderror" name="groups"
+                   id="groups"
+                   value="{{ old('groups', $schedule->groups ?? '') }}">
+            @error('groups')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+            <small id="groupsHelpBlock" class="form-text text-muted">
+                {{ trans('schedule::schedule.messages.help-type', ['type' => strtolower(trans('schedule::schedule.fields.groups'))]) }}
+            </small>
+        </div>
+    @endif
+
     <div class="form-group">
         <label>{{ trans('schedule::schedule.fields.log_filename') }}</label>
         <input type="text" class="form-control @error('log_filename') is-invalid @enderror" name="log_filename"
-               id="log_file"
+               id="log_filename"
                value="{{ old('log_filename', $schedule->log_filename ?? '') }}">
         @error('log_filename')
             <div class="invalid-feedback">{{ $message }}</div>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -17,88 +17,87 @@
                  route: ''
             }">
                 @include('schedule::delete-modal')
-                <table class="table table-bordered table-striped table-sm table-hover">
-                    <thead>
-                    <tr>
-                        {{ Helpers::buildHeader() }}
-                    </tr>
-                    <tbody>
-                    @forelse($schedules as $schedule)
+
+                @if ($schedules->isEmpty())
+                    <p> {{ trans('schedule::schedule.messages.no-records-found') }} </p>
+                @else
+                    <table class="table table-bordered table-striped table-sm table-hover">
+                        <thead>
                         <tr>
-                            <td>{{ $schedule->command }}@if ($schedule->command == 'custom')
-                                    : {{ $schedule->command_custom }} @endif</td>
-                            <td>
-                                @if(isset($schedule->params))
-                                    @foreach($schedule->params as $param => $value)
-                                        @if(isset($value['value']))
-                                            {{ $param }}
-                                            ={{ $value['value'] }}{{ $value['type'] === 'function' ? '()' : ''}}<br>
-                                        @endif
-                                    @endforeach
-                                @endif
-                            </td>
-                            <td>
-                                @if(isset($schedule->options))
-                                    @foreach($schedule->options as $option => $value)
-                                        @if(!is_array($value) || isset($value['value']))
-                                            @if(is_array($value))
-                                                --{{ $option }}
-                                                ={{ $value['value'] }}{{ $value['type'] === 'function' ? '()' : ''}}
-                                            @else
-                                                --{{ $option }}
+                            {{ Helpers::buildHeader() }}
+                        </tr>
+                        <tbody>
+                        @foreach($schedules as $schedule)
+                            <tr>
+                                <td>{{ $schedule->command }}@if ($schedule->command == 'custom')
+                                        : {{ $schedule->command_custom }} @endif</td>
+                                <td>
+                                    @if(isset($schedule->params))
+                                        @foreach($schedule->params as $param => $value)
+                                            @if(isset($value['value']))
+                                                {{ $param }}
+                                                ={{ $value['value'] }}{{ $value['type'] === 'function' ? '()' : ''}}<br>
                                             @endif
-                                            <br>
-                                        @endif
-                                    @endforeach
+                                        @endforeach
+                                    @endif
+                                </td>
+                                <td>
+                                    @if(isset($schedule->options))
+                                        @foreach($schedule->options as $option => $value)
+                                            @if(!is_array($value) || isset($value['value']))
+                                                @if(is_array($value))
+                                                    --{{ $option }}
+                                                    ={{ $value['value'] }}{{ $value['type'] === 'function' ? '()' : ''}}
+                                                @else
+                                                    --{{ $option }}
+                                                @endif
+                                                <br>
+                                            @endif
+                                        @endforeach
+                                    @endif
+                                </td>
+                                <td class="text-center">{{ $schedule->expression }}</td>
+                                @if(config('database-schedule.enable_groups', false))
+                                    <td class="text-center">{{ $schedule->groups }}</td>
                                 @endif
-                            </td>
-                            <td class="text-center">{{ $schedule->expression }}</td>
-                            @if(config('database-schedule.enable_groups', false))
-                                <td class="text-center">{{ $schedule->groups }}</td>
-                            @endif
-                            <td class="text-center">{{ $schedule->created_at }}</td>
-                            <td class="text-center">{{ $schedule->created_at == $schedule->updated_at ? trans('schedule::schedule.fields.never') : $schedule->updated_at }}</td>
-                            <td class="text-center {{ $schedule->status ? 'text-success' : 'text-secondary' }}">
-                                {{ $schedule->status ? trans('schedule::schedule.status.active') : trans('schedule::schedule.status.inactive') }}
-                            </td>
-                            <td class="text-center">
-                                <a href="{{ action('\RobersonFaria\DatabaseSchedule\Http\Controllers\ScheduleController@show', $schedule) }}"
-                                   class="btn btn-sm btn-info">
-                                    <i title="{{ trans('schedule::schedule.buttons.history') }}"
-                                       class="bi bi-journal"> </i>
-                                </a>
-                                <a href="{{ action('\RobersonFaria\DatabaseSchedule\Http\Controllers\ScheduleController@edit', $schedule) }}"
-                                   class="btn btn-sm btn-primary">
-                                    <i title="{{ trans('schedule::schedule.buttons.edit') }}"
-                                       class="bi bi-pencil-square"></i>
-                                </a>
-                                <form action="{{ route(config('database-schedule.route.name', 'database-schedule') . '.status', ['schedule' => $schedule->id, 'status' => $schedule->status ? 0 : 1]) }}"
-                                      method="POST" class="d-inline">
-                                    @csrf
-                                    <button type="submit"
-                                            class="btn btn-{{ $schedule->status ? 'secondary' : 'success' }} btn-sm">
-                                        <i title="{{ trans('schedule::schedule.buttons.' . ($schedule->status ? 'inactivate' : 'activate')) }}"
-                                           class="bi {{ ($schedule->status ? 'bi-pause' : 'bi-play') }}"></i>
+                                <td class="text-center">{{ $schedule->created_at }}</td>
+                                <td class="text-center">{{ $schedule->created_at == $schedule->updated_at ? trans('schedule::schedule.fields.never') : $schedule->updated_at }}</td>
+                                <td class="text-center {{ $schedule->status ? 'text-success' : 'text-secondary' }}">
+                                    {{ $schedule->status ? trans('schedule::schedule.status.active') : trans('schedule::schedule.status.inactive') }}
+                                </td>
+                                <td class="text-center">
+                                    <a href="{{ action('\RobersonFaria\DatabaseSchedule\Http\Controllers\ScheduleController@show', $schedule) }}"
+                                       class="btn btn-sm btn-info">
+                                        <i title="{{ trans('schedule::schedule.buttons.history') }}"
+                                           class="bi bi-journal"> </i>
+                                    </a>
+                                    <a href="{{ action('\RobersonFaria\DatabaseSchedule\Http\Controllers\ScheduleController@edit', $schedule) }}"
+                                       class="btn btn-sm btn-primary">
+                                        <i title="{{ trans('schedule::schedule.buttons.edit') }}"
+                                           class="bi bi-pencil-square"></i>
+                                    </a>
+                                    <form action="{{ route(config('database-schedule.route.name', 'database-schedule') . '.status', ['schedule' => $schedule->id, 'status' => $schedule->status ? 0 : 1]) }}"
+                                          method="POST" class="d-inline">
+                                        @csrf
+                                        <button type="submit"
+                                                class="btn btn-{{ $schedule->status ? 'secondary' : 'success' }} btn-sm">
+                                            <i title="{{ trans('schedule::schedule.buttons.' . ($schedule->status ? 'inactivate' : 'activate')) }}"
+                                               class="bi {{ ($schedule->status ? 'bi-pause' : 'bi-play') }}"></i>
+                                        </button>
+                                    </form>
+                                    <button
+                                            x-on:click="message=messageTemplate.replace(':cronjob', '{{ $schedule->command }}'); route=routeTemplate.replace('#ID#', {{ $schedule->id }})"
+                                            type="button" class="btn btn-danger btn-sm"
+                                            data-toggle="modal"
+                                            data-target="#delete-modal">
+                                        <i title="{{ trans('schedule::schedule.buttons.delete') }}" class="bi bi-trash"></i>
                                     </button>
-                                </form>
-                                <button
-                                        x-on:click="message=messageTemplate.replace(':cronjob', '{{ $schedule->command }}'); route=routeTemplate.replace('#ID#', {{ $schedule->id }})"
-                                        type="button" class="btn btn-danger btn-sm"
-                                        data-toggle="modal"
-                                        data-target="#delete-modal">
-                                    <i title="{{ trans('schedule::schedule.buttons.delete') }}" class="bi bi-trash"></i>
-                                </button>
-                            </td>
-                        </tr>
-                    @empty
-                        <tr>
-                            <td colspan="6" class="text-center">
-                                {{ trans('schedule::schedule.messages.no-records-found') }}
-                            </td>
-                        </tr>
-                    @endforelse
-                    </tbody>
-                </table>
+                                </td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                @endif
                 <div class='d-flex'>
                     <div class='mx-auto'>
                         {{ $schedules->links() }}

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -8,6 +8,9 @@
                 <small><code>
                         {{ trans('schedule::schedule.messages.timezone') }}{{ config('database-schedule.timezone') }}
                     </code></small>
+                    <span style="float: right;">
+                        <a href="{{ config('app.url', '/') }}"><i class="bi bi-house-fill"></i> {{ trans('schedule::schedule.titles.back_to_application') }}</a>
+                    </span>
             </div>
             <div class="card-body table-responsive"
                  x-data="{
@@ -63,6 +66,7 @@
                                 @if(config('database-schedule.enable_groups', false))
                                     <td class="text-center">{{ $schedule->groups }}</td>
                                 @endif
+                                <td class="text-center">{{ $schedule->environments }}</td>
                                 <td class="text-center">{{ $schedule->created_at }}</td>
                                 <td class="text-center">{{ $schedule->created_at == $schedule->updated_at ? trans('schedule::schedule.fields.never') : $schedule->updated_at }}</td>
                                 <td class="text-center {{ $schedule->status ? 'text-success' : 'text-secondary' }}">

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -53,6 +53,9 @@
                                 @endif
                             </td>
                             <td class="text-center">{{ $schedule->expression }}</td>
+                            @if(config('database-schedule.enable_groups', false))
+                                <td class="text-center">{{ $schedule->groups }}</td>
+                            @endif
                             <td class="text-center">{{ $schedule->created_at }}</td>
                             <td class="text-center">{{ $schedule->created_at == $schedule->updated_at ? trans('schedule::schedule.fields.never') : $schedule->updated_at }}</td>
                             <td class="text-center {{ $schedule->status ? 'text-success' : 'text-secondary' }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,10 +5,19 @@ use Illuminate\Support\Facades\Route;
 Route::post('/{schedule}/status/{status}', 'ScheduleController@status')
     ->name(config('database-schedule.route.name', 'database-schedule') . '.status');
 
-Route::get('/', 'ScheduleController@index')
+Route::get('/', function() {
+    return redirect()->route(config('database-schedule.route.name', 'database-schedule') . '.index');
+});
+
+Route::match(['get', 'post'], '/index', 'ScheduleController@index')
     ->name(config('database-schedule.route.name', 'database-schedule') . '.index');
+
 Route::post('/', 'ScheduleController@store')
     ->name(config('database-schedule.route.name', 'database-schedule') . '.store');
+Route::post('/filter', 'ScheduleController@filter')
+    ->name(config('database-schedule.route.name', 'database-schedule') . '.filter');
+Route::post('/filter-reset', 'ScheduleController@filterReset')
+    ->name(config('database-schedule.route.name', 'database-schedule') . '.filter-reset');
 Route::get('/create', 'ScheduleController@create')
     ->name(config('database-schedule.route.name', 'database-schedule') . '.create');
 Route::put('/{schedule}', 'ScheduleController@update')
@@ -19,3 +28,12 @@ Route::delete('/{schedule}', 'ScheduleController@destroy')
     ->name(config('database-schedule.route.name', 'database-schedule') . '.destroy');
 Route::get('/{schedule}/edit', 'ScheduleController@edit')
     ->name(config('database-schedule.route.name', 'database-schedule') . '.edit');
+
+// @link https://laracasts.com/discuss/channels/laravel/route-model-binding-with-soft-deleted-model
+Route::post('/{thrashed_schedule}/restore', 'ScheduleController@restore')
+    ->name(config('database-schedule.route.name', 'database-schedule') . '.restore');
+Route::bind('thrashed_schedule', function ($id) {
+    $schedule = app(config('database-schedule.model'));
+    return $schedule::onlyTrashed()->find($id);
+});
+

--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -30,6 +30,10 @@ class Schedule
             //ensure output is being captured to write history
             $event->storeOutput();
 
+            if($task->environments) {
+                $event->environments(explode(',', $task->environments));
+            }
+
             if ($task->even_in_maintenance_mode) {
                 $event->evenInMaintenanceMode();
             }

--- a/src/Http/Controllers/ScheduleController.php
+++ b/src/Http/Controllers/ScheduleController.php
@@ -3,7 +3,9 @@
 namespace RobersonFaria\DatabaseSchedule\Http\Controllers;
 
 use RobersonFaria\DatabaseSchedule\Http\Requests\ScheduleRequest;
+use RobersonFaria\DatabaseSchedule\Http\Services\CommandService;
 use RobersonFaria\DatabaseSchedule\Models\Schedule;
+use RobersonFaria\DatabaseSchedule\View\Helpers;
 
 class ScheduleController extends Controller
 {
@@ -15,17 +17,59 @@ class ScheduleController extends Controller
     public function index()
     {
         $schedule = app(config('database-schedule.model'));
+        $schedules = $schedule::query();
 
-        $orderBy = request()->get('orderBy') ?? config('database-schedule.default_ordering', 'created_at');
-        $direction = request()->get('direction') ?? config('database-schedule.default_ordering_direction', 'DESC');
+				$orderBy = request()->input('orderBy')
+					?? session()->get(Schedule::SESSION_KEY_ORDER_BY)
+					?? config('database-schedule.default_ordering', 'created_at');
+				$direction = request()->input('direction')
+					?? session()->get(Schedule::SESSION_KEY_DIRECTION)
+					?? config('database-schedule.default_ordering_direction', 'DESC');
 
-        $schedules = $schedule::query()
-            ->orderBy($orderBy, $direction)
-            ->paginate(config('database-schedule.per_page', 10));
+				session()->put(Schedule::SESSION_KEY_ORDER_BY, $orderBy);
+        session()->put(Schedule::SESSION_KEY_DIRECTION, $direction);
 
-        return view('schedule::index')
-            ->with(compact('schedules'));
+        foreach (session()->get(Schedule::SESSION_KEY_FILTERS, []) as $column => $value) {
+            if ($column === 'status') {
+                if ($value === Schedule::STATUS_TRASHED) {
+                    $schedules->onlyTrashed();
+                } else if ($value === Schedule::STATUS_INACTIVE) {
+                    $schedules->inactive();
+                } else if ($value === Schedule::STATUS_ACTIVE) {
+                    $schedules->active();
+                }
+            } else if ($column === 'command') {
+                // also search in job descriptions:
+                $schedules->where(function ($query) use ($value) {
+                    $query->orWhere('command', 'like', '%'.$value.'%');
+
+                    $commands = (new CommandService())->get()->filter(function ($command) use ($value) {
+                        return false !== stristr($command->description, $value);
+                    })->pluck('name');
+
+                    foreach ($commands as $command) {
+                        $query->orWhere('command', 'like', '%'.$command .'%');
+                    }
+                });
+            } else if ($value) {
+                $schedules->where($column, 'like', '%'.$value.'%');
+            }
+        }
+
+				$schedules = $schedules
+					->orderBy($orderBy, $direction)
+					->paginate(config('database-schedule.per_page', 10));
+
+        return view('schedule::index')->with(compact('schedules', 'orderBy', 'direction'));
     }
+
+    public function filter()
+    {
+        session()->put(Schedule::SESSION_KEY_FILTERS, request()->input('filters'));
+
+        return redirect()->to(Helpers::indexRoute());
+    }
+
 
     /**
      * Show the form for creating a new schedule.
@@ -148,5 +192,36 @@ class ScheduleController extends Controller
                 ->with('error', trans('schedule::schedule.messages.save-error'))
                 ->withInput();
         }
+    }
+
+    /**
+     * Restore a thrashed schedule
+     *
+     * @param Schedule $schedule
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function restore(Schedule $schedule)
+    {
+        try {
+            $schedule->restore();
+
+            return redirect()
+                ->action('\RobersonFaria\DatabaseSchedule\Http\Controllers\ScheduleController@index')
+                ->with('success', trans('schedule::schedule.messages.save-success'));
+        } catch (\Exception $e) {
+            report($e);
+            return back()
+                ->with('error', trans('schedule::schedule.messages.save-error'))
+                ->withInput();
+        }
+    }
+
+    public function filterReset()
+    {
+				session()->forget(Schedule::SESSION_KEY_ORDER_BY);
+        session()->forget(Schedule::SESSION_KEY_DIRECTION);
+        session()->forget(Schedule::SESSION_KEY_FILTERS);
+
+        return redirect()->to(Helpers::indexRoute());
     }
 }

--- a/src/Http/Requests/ScheduleRequest.php
+++ b/src/Http/Requests/ScheduleRequest.php
@@ -31,7 +31,8 @@ class ScheduleRequest extends FormRequest
             'webhook_after' => 'nullable|url',
             'email_output' => 'requiredIf:sendmail_error,1|requiredIf:sendmail_success,1|nullable|email',
             'log_filename' => 'nullable|alpha_dash',
-            'groups' => 'nullable|regex:/^[A-Za-z-_0-9,]*$/'
+            'groups' => 'nullable|regex:/^[A-Za-z-_0-9,]*$/',
+            'environments' => 'nullable|regex:/^[A-Za-z-_0-9,]*$/',
         ];
     }
 
@@ -67,8 +68,9 @@ class ScheduleRequest extends FormRequest
     public function messages()
     {
         return [
-            'validation.cron' => 'The field must be filled in the cron expression format.',
-            'groups.regex' => trans('schedule::schedule.validation.regex')
+            'groups.regex' => trans('schedule::schedule.validation.regex'),
+            'expression.cron' => trans('schedule::schedule.validation.cron'),
+            'environments.regex' => trans('schedule::schedule.validation.regex'),
         ];
     }
 }

--- a/src/Http/Requests/ScheduleRequest.php
+++ b/src/Http/Requests/ScheduleRequest.php
@@ -30,7 +30,8 @@ class ScheduleRequest extends FormRequest
             'webhook_before' => 'nullable|url',
             'webhook_after' => 'nullable|url',
             'email_output' => 'requiredIf:sendmail_error,1|requiredIf:sendmail_success,1|nullable|email',
-            'log_filename' => 'nullable|alpha_dash'
+            'log_filename' => 'nullable|alpha_dash',
+            'groups' => 'nullable|regex:/^[A-Za-z-_0-9,]*$/'
         ];
     }
 
@@ -66,7 +67,8 @@ class ScheduleRequest extends FormRequest
     public function messages()
     {
         return [
-            'validation.cron' => 'The field must be filled in the cron expression format.'
+            'validation.cron' => 'The field must be filled in the cron expression format.',
+            'groups.regex' => trans('schedule::schedule.validation.regex')
         ];
     }
 }

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -45,7 +45,8 @@ class Schedule extends Model
         'status',
         'run_in_background',
         'log_filename',
-        'groups'
+        'groups',
+        'environments',
     ];
 
     protected $attributes = [
@@ -56,7 +57,7 @@ class Schedule extends Model
 
     protected $casts = [
         'params' => 'array',
-        'options' => 'array',
+        'options' => 'array'
     ];
 
     /**

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -136,4 +136,12 @@ class Schedule extends Model
             ->get('groups')
             ->pluck('groups', 'groups');
     }
+
+    public static function getEnvironments()
+    {
+        return static::whereNotNull('environments')
+            ->groupBy('environments')
+            ->get('environments')
+            ->pluck('environments', 'environments');
+    }
 }

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -11,6 +11,14 @@ class Schedule extends Model
 {
     use ManagesFrequencies, SoftDeletes;
 
+    public const SESSION_KEY_ORDER_BY = 'schedule_order_by';
+    public const SESSION_KEY_DIRECTION = 'schedule_order_by_direction';
+    public const SESSION_KEY_FILTERS = 'schedule_filters';
+
+    public const STATUS_INACTIVE = '0';
+    public const STATUS_ACTIVE = '1';
+    public const STATUS_TRASHED = '2';
+
     /**
      * The database table used by the model.
      *
@@ -69,6 +77,12 @@ class Schedule extends Model
         return $this->hasMany(ScheduleHistory::class, 'schedule_id', 'id');
     }
 
+
+    public function scopeInactive($query)
+    {
+        return $query->where('status', false);
+    }
+
     public function scopeActive($query)
     {
         return $query->where('status', true);
@@ -112,5 +126,13 @@ class Schedule extends Model
         }
 
         return $options;
+    }
+
+    public static function getGroups()
+    {
+        return static::whereNotNull('groups')
+            ->groupBy('groups')
+            ->get('groups')
+            ->pluck('groups', 'groups');
     }
 }

--- a/src/Models/Schedule.php
+++ b/src/Models/Schedule.php
@@ -36,7 +36,8 @@ class Schedule extends Model
         'log_error',
         'status',
         'run_in_background',
-        'log_filename'
+        'log_filename',
+        'groups'
     ];
 
     protected $attributes = [

--- a/src/View/Helpers.php
+++ b/src/View/Helpers.php
@@ -6,10 +6,25 @@ use Illuminate\Support\HtmlString;
 
 class Helpers
 {
+    private static $columns = [
+        'command',
+        'arguments',
+        'options',
+        'expression',
+        'groups',
+        'created_at',
+        'updated_at',
+        'status',
+        'actions',
+    ];
+
     public static function buildHeader(): HtmlString
     {
         $header = '';
-        foreach (['command', 'arguments', 'options', 'expression', 'created_at', 'updated_at', 'status', 'actions'] as $column) {
+        foreach (static::$columns as $column) {
+            if($column === 'groups' && config('database-schedule.enable_groups', false) === false) {
+                continue;
+            }
             $caption = static::highlight($column, trans("schedule::schedule.fields.$column"));
             $direction = request()->get('direction') === 'asc' ? 'desc' : 'asc';
             if ($column === 'arguments' || $column === 'actions') {

--- a/src/View/Helpers.php
+++ b/src/View/Helpers.php
@@ -3,6 +3,7 @@
 namespace RobersonFaria\DatabaseSchedule\View;
 
 use Illuminate\Support\HtmlString;
+use RobersonFaria\DatabaseSchedule\Models\Schedule;
 
 class Helpers
 {
@@ -20,31 +21,90 @@ class Helpers
 
     public static function buildHeader(): HtmlString
     {
-        $header = '';
+        $header = '<tr>';
         foreach (static::$columns as $column) {
             if($column === 'groups' && config('database-schedule.enable_groups', false) === false) {
                 continue;
             }
             $caption = static::highlight($column, trans("schedule::schedule.fields.$column"));
-            $direction = request()->get('direction') === 'asc' ? 'desc' : 'asc';
+            $direction = session()->get(Schedule::SESSION_KEY_DIRECTION) === 'asc' ? 'desc' : 'asc';
             if ($column === 'arguments' || $column === 'actions') {
                 $header .= sprintf('<th class="text-center text-nowrap">%s</th>', $caption);
             } else {
-                $routeName = config('database-schedule.route.name', 'database-schedule') . '.index';
-                $params = ['orderBy' => $column, 'direction' => $direction];
-                $route = route($routeName, $params);
+                $route = static::indexRoute(['orderBy' => $column, 'direction' => $direction]);
                 $header .= sprintf('<th class="text-center text-nowrap"><a href="%s">%s</a></th>', $route, $caption);
             }
         }
 
+        $header .= '</tr>';
+
         return new HtmlString($header);
     }
 
+    public static function buildFilter(): HtmlString
+    {
+        $filter = '<tr>';
+        $js = "document.getElementById('schedule-filter-form').submit();";
+
+        $schedule = app(config('database-schedule.model'));
+
+        $filters = session()->get(Schedule::SESSION_KEY_FILTERS);
+
+        foreach (static::$columns as $column) {
+            switch($column) {
+                case 'arguments':
+                    $content = '';
+                    break;
+                case 'actions':
+                    $content = '<button form="schedule-filter-form" title="Filter" class="btn-sm btn-primary" type="submit"><i class="bi bi-search"></i></button>&nbsp;';
+                    $content .= '<button form="schedule-filter-reset" type="submit" title="Reset" class="btn-sm btn-success"><i class="bi bi-x-circle-fill"></i></button>';
+                    break;
+                case 'groups':
+                    $content = view('schedule::dropdown', [
+                        'name' => 'filters[groups]',
+                        'js' => $js,
+                        'options' => $schedule::getGroups(),
+                        'selected' => $filters['groups'] ?? null,
+                    ]);
+                    break;
+                case 'status':
+                    $content = view('schedule::dropdown', [
+                        'name' => 'filters[status]',
+                        'js' => $js,
+                        'options' => [
+                            2 => trans('schedule::schedule.status.trashed'),
+                            0 => trans('schedule::schedule.status.inactive'),
+                            1 => trans('schedule::schedule.status.active'),
+                        ],
+                        'selected' => $filters['status'] ?? null,
+                    ]);
+                    break;
+                default:
+                    $content = sprintf(
+                        '<input @blur="%s" value="%s" form="schedule-filter-form" type="text" class="form-control" name="filters[%s]">',
+                        $js,
+                        $filters[$column] ?? '',
+                        $column);
+                    break;
+            }
+
+            $filter .= sprintf('<th class="text-center">%s</th>', $content);
+        }
+
+        $filter .= '</tr>';
+
+        return new HtmlString($filter);
+    }
+
+    public static function indexRoute(array $params = []): string
+    {
+        return route(config('database-schedule.route.name', 'database-schedule') . '.index', $params);
+    }
 
     private static function highlight($orderBy, $caption): string
     {
-        if (request()->has('orderBy') && request()->get('orderBy') === $orderBy) {
-            $direction = request()->get('direction') === 'asc' ? 'up' : 'down';
+        if ($orderBy === session()->get(Schedule::SESSION_KEY_ORDER_BY)) {
+            $direction = session()->get(Schedule::SESSION_KEY_DIRECTION) === 'asc' ? 'up' : 'down';
             return sprintf('%s<i class="bi bi-sort-alpha-%s"></i>', $caption, $direction);
         }
 

--- a/src/View/Helpers.php
+++ b/src/View/Helpers.php
@@ -13,6 +13,7 @@ class Helpers
         'options',
         'expression',
         'groups',
+        'environments',
         'created_at',
         'updated_at',
         'status',
@@ -23,7 +24,7 @@ class Helpers
     {
         $header = '<tr>';
         foreach (static::$columns as $column) {
-            if($column === 'groups' && config('database-schedule.enable_groups', false) === false) {
+            if ($column === 'groups' && config('database-schedule.enable_groups', false) === false) {
                 continue;
             }
             $caption = static::highlight($column, trans("schedule::schedule.fields.$column"));

--- a/src/View/Helpers.php
+++ b/src/View/Helpers.php
@@ -20,13 +20,19 @@ class Helpers
         'actions',
     ];
 
+    public static function getColumns()
+    {
+        if (config('database-schedule.enable_groups', false)) {
+            return static::$columns;
+        }
+
+        return array_diff(static::$columns, ['groups']);
+    }
+
     public static function buildHeader(): HtmlString
     {
         $header = '<tr>';
-        foreach (static::$columns as $column) {
-            if ($column === 'groups' && config('database-schedule.enable_groups', false) === false) {
-                continue;
-            }
+        foreach (static::getColumns() as $column) {
             $caption = static::highlight($column, trans("schedule::schedule.fields.$column"));
             $direction = session()->get(Schedule::SESSION_KEY_DIRECTION) === 'asc' ? 'desc' : 'asc';
             if ($column === 'arguments' || $column === 'actions') {
@@ -51,7 +57,7 @@ class Helpers
 
         $filters = session()->get(Schedule::SESSION_KEY_FILTERS);
 
-        foreach (static::$columns as $column) {
+        foreach (static::getColumns() as $column) {
             switch($column) {
                 case 'arguments':
                     $content = '';
@@ -66,6 +72,14 @@ class Helpers
                         'js' => $js,
                         'options' => $schedule::getGroups(),
                         'selected' => $filters['groups'] ?? null,
+                    ]);
+                    break;
+                case 'environments':
+                    $content = view('schedule::dropdown', [
+                        'name' => 'filters[environments]',
+                        'js' => $js,
+                        'options' => $schedule::getEnvironments(),
+                        'selected' => $filters['environments'] ?? null,
                     ]);
                     break;
                 case 'status':


### PR DESCRIPTION
When dealing with a lot of jobs (we will have 100+) it is useful to order the jobs by given groups.
By default this feature is turned off.