### PR TITLE
Arguments fix

### DIFF
--- a/src/Console/Scheduling/Schedule.php
+++ b/src/Console/Scheduling/Schedule.php
@@ -43,7 +43,7 @@ class Schedule
                 $command = $task->command;
                 $event = $this->schedule->command(
                     $command,
-                    $task->getArguments() + $task->getOptions()
+                    array_values($task->getArguments()) + $task->getOptions()
                 );
             }
             $event->cron($task->expression);

--- a/tests/Feature/ScheduleCommandTest.php
+++ b/tests/Feature/ScheduleCommandTest.php
@@ -52,7 +52,10 @@ class ScheduleCommandTest extends TestCase
         $events->each(function (\Illuminate\Console\Scheduling\Event $event) use ($task) {
             // This example is for hourly commands.
             $this->assertEquals($task->expression, $event->expression);
-            $this->assertStringEndsWith("phpunit:test argument='this is a argument'", $event->command);
+            $this->assertStringEndsWith(
+                "phpunit:test 'this is a argument'",
+                $event->command
+            );
         });
     }
 
@@ -75,7 +78,9 @@ class ScheduleCommandTest extends TestCase
         /** @var \Illuminate\Console\Scheduling\Schedule $schedule */
         $schedule = app()->make(\Illuminate\Console\Scheduling\Schedule::class);
 
-        $events = collect($schedule->events())->filter(function (\Illuminate\Console\Scheduling\Event $event) use ($task) {
+        $events = collect(
+            $schedule->events())->filter(
+                function (\Illuminate\Console\Scheduling\Event $event) use ($task) {
             return stripos($event->command, $task->command);
         });
 
@@ -86,7 +91,10 @@ class ScheduleCommandTest extends TestCase
         $events->each(function (\Illuminate\Console\Scheduling\Event $event) use ($task) {
             // This example is for hourly commands.
             $this->assertEquals($task->expression, $event->expression);
-            $this->assertStringEndsWith("phpunit:test argument='this is a argument' optionalArgument='this is a optional argument'", $event->command);
+            $this->assertStringEndsWith(
+                "phpunit:test 'this is a argument' 'this is a optional argument'",
+                $event->command
+            );
         });
     }
 }

--- a/tests/Feature/ScheduleCommandTest.php
+++ b/tests/Feature/ScheduleCommandTest.php
@@ -70,7 +70,7 @@ class ScheduleCommandTest extends TestCase
                         'type' => 'string'
                     ],
                     'optionalArgument' => [
-                        'value' => 'this is a optional argument',
+                        'value' => 'optional argument',
                         'type' => 'string'
                     ]
                 ]
@@ -78,23 +78,26 @@ class ScheduleCommandTest extends TestCase
         /** @var \Illuminate\Console\Scheduling\Schedule $schedule */
         $schedule = app()->make(\Illuminate\Console\Scheduling\Schedule::class);
 
-        $events = collect(
-            $schedule->events())->filter(
+        $events = collect($schedule->events())
+            ->filter(
                 function (\Illuminate\Console\Scheduling\Event $event) use ($task) {
-            return stripos($event->command, $task->command);
-        });
+                    return stripos($event->command, $task->command);
+                }
+            );
 
         if ($events->count() == 0) {
             $this->fail('No events found');
         }
 
-        $events->each(function (\Illuminate\Console\Scheduling\Event $event) use ($task) {
-            // This example is for hourly commands.
-            $this->assertEquals($task->expression, $event->expression);
-            $this->assertStringEndsWith(
-                "phpunit:test 'this is a argument' 'this is a optional argument'",
-                $event->command
-            );
-        });
+        $events->each(
+            function (\Illuminate\Console\Scheduling\Event $event) use ($task) {
+                // This example is for hourly commands.
+                $this->assertEquals($task->expression, $event->expression);
+                $this->assertStringEndsWith(
+                    "phpunit:test 'this is a argument' 'optional argument'",
+                    $event->command
+                );
+            }
+        );
     }
 }

--- a/tests/Unit/ScheduleCommandsTest.php
+++ b/tests/Unit/ScheduleCommandsTest.php
@@ -64,7 +64,7 @@ class ScheduleCommandsTest extends TestCase
         $this->mock(\Illuminate\Console\Scheduling\Schedule::class, function (Mockery\MockInterface $mock) {
             $mock->shouldReceive('command')
                 ->once()
-                ->with('inspire', ['test' => '1'])
+                ->with('inspire', ['1'])
                 ->andReturn($this->event);
         });
 


### PR DESCRIPTION
Assume we have a command:

```php
        protected $signature = 'group:backup {server}';
```

and configure laravel-database-schedule to run, currently it runs:

`php artisan group:backup server='my-server'`

which is wrong; it should run:

`php artisan group:backup my-server`

This MR fixes that problem.