### PR TITLE
introduce ability to set 'verbose', 'quiet', 'ansi', 'no-ansi'

### DIFF
--- a/src/Http/Services/CommandService.php
+++ b/src/Http/Services/CommandService.php
@@ -44,7 +44,9 @@ class CommandService
     {
         $options = (object)[
             'withValue' => [],
-            'withoutValue' => []
+            'withoutValue' => [
+              'verbose', 'quiet', 'ansi', 'no-ansi',
+            ]
         ];
         foreach ($command->getDefinition()->getOptions() as $option) {
             if ($option->acceptValue()) {


### PR DESCRIPTION
 options which are laravel command default options that should be included in every command