### PR TITLE
True Laravel 11 support

### DIFF
--- a/config/database-schedule.php
+++ b/config/database-schedule.php
@@ -90,7 +90,16 @@ return [
             'queue:*',
             'schedule:*',
             'view:*',
-            'phpunit:*'
+            'phpunit:*',
+            'install:*',
+            'channel:*',
+            'about',
+            'docs',
+            'model:*',
+            'storage:unlink',
+            'lang:publish',
+            '_complete',
+            'completion',
         ]
     ],
 

--- a/src/DatabaseSchedulingServiceProvider.php
+++ b/src/DatabaseSchedulingServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Console\Scheduling\Schedule as BaseSchedule;
 use RobersonFaria\DatabaseSchedule\Console\Commands\TestJobCommand;
 use RobersonFaria\DatabaseSchedule\Console\Commands\ScheduleClearCacheCommand;
 use RobersonFaria\DatabaseSchedule\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Schema;
 
 class DatabaseSchedulingServiceProvider extends DatabaseScheduleApplicationServiceProvider
 {
@@ -63,8 +64,10 @@ class DatabaseSchedulingServiceProvider extends DatabaseScheduleApplicationServi
         }
 
         $this->app->resolving(BaseSchedule::class, function ($schedule) {
-            $schedule = app(Schedule::class, ['schedule' => $schedule]);
-            return $schedule->execute();
+            if (Schema::hasTable('schedules')) {
+                $schedule = app(Schedule::class, ['schedule' => $schedule]);
+                return $schedule->execute();
+            }
         });
 
         $this->commands([

--- a/src/Http/Services/CommandService.php
+++ b/src/Http/Services/CommandService.php
@@ -9,7 +9,7 @@ class CommandService
 {
     public function get(): Collection
     {
-        $commands = collect(app( Artisan::class)->all())->sortKeys();
+        $commands = collect(Artisan::all())->sortKeys();
         $commandsKeys = $commands->keys()->toArray();
         foreach (config('database-schedule.commands.exclude') as $exclude) {
             $commandsKeys = preg_grep("/^$exclude/", $commandsKeys, PREG_GREP_INVERT);

--- a/src/Http/Services/CommandService.php
+++ b/src/Http/Services/CommandService.php
@@ -2,14 +2,14 @@
 
 namespace RobersonFaria\DatabaseSchedule\Http\Services;
 
-use App\Console\Kernel;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Collection;
 
 class CommandService
 {
     public function get(): Collection
     {
-        $commands = collect(app(Kernel::class)->all())->sortKeys();
+        $commands = collect(app( Artisan::class)->all())->sortKeys();
         $commandsKeys = $commands->keys()->toArray();
         foreach (config('database-schedule.commands.exclude') as $exclude) {
             $commandsKeys = preg_grep("/^$exclude/", $commandsKeys, PREG_GREP_INVERT);


### PR DESCRIPTION
Since kernel.php no longer exists we needed to get the atrisan commands another way.  Also it seems during setup that it tries to do some scheduling before the schedules table exists, so added some code for that.